### PR TITLE
Add targets to recursive archive generator

### DIFF
--- a/recursive-archive-generator/generate
+++ b/recursive-archive-generator/generate
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Generate a recursive archive to test with
 # ./generate will generate a recursive archive
-# ./generate --include-targes will add a package.json and a pom.xml to the archives
+# ./generate --include-targets will add a package.json and a pom.xml to the archives
 # ./generate --skip-archiving will just create the directory structure, but skip the archiving
 
 WORKING_DIR=`pwd`

--- a/recursive-archive-generator/generate
+++ b/recursive-archive-generator/generate
@@ -2,6 +2,12 @@
 WORKING_DIR=`pwd`
 echo "WORKING_DIR = $WORKING_DIR"
 
+include_targets="false"
+if [[ "$1" == "--include-targets" ]]; then
+  echo "Including targets (copies a package.json and a pom.xml into the archives)"
+  include_targets="true"
+fi
+
 # Make the files
 rm -rf recursive-archive
 mkdir -p recursive-archive/vendor/foo/bar/baz/quux
@@ -10,6 +16,10 @@ cp MIT_LICENSE recursive-archive/vendor/foo/bar/baz/SOMETHING_LICENSE
 cp apache_licensed_codefile.rb recursive-archive/vendor/foo/bar/baz/something.rb
 cp apache_licensed_codefile.rb recursive-archive/vendor/foo/bar/bar_apache.rb
 cp MIT_LICENSE recursive-archive/vendor/foo/bar
+if [[ "$include_targets" == "true" ]]; then
+  cp package.json recursive-archive/vendor/foo/bar/baz/quux
+  cp pom.xml recursive-archive/vendor/foo/bar/
+fi
 # The UUID gives us a different directory hash every time we generate
 uuidgen > recursive-archive/vendor/foo/VERSION
 
@@ -18,6 +28,7 @@ if [[ "$1" == "--skip-archiving" ]]; then
   echo "Exiting early"
   exit 0
 fi
+
 # output the file-tree before tarring things up
 echo "un-archived directory structure: "
 tree recursive-archive

--- a/recursive-archive-generator/generate
+++ b/recursive-archive-generator/generate
@@ -3,10 +3,22 @@ WORKING_DIR=`pwd`
 echo "WORKING_DIR = $WORKING_DIR"
 
 include_targets="false"
-if [[ "$1" == "--include-targets" ]]; then
-  echo "Including targets (copies a package.json and a pom.xml into the archives)"
-  include_targets="true"
-fi
+skip_archiving="false"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --include-targets)
+      include_targets="true"
+      shift # past value
+      ;;
+    --skip-archiving)
+      skip_archiving="true"
+      shift # past value
+      ;;
+    *)
+      shift # past argument
+      ;;
+  esac
+done
 
 # Make the files
 rm -rf recursive-archive
@@ -16,15 +28,16 @@ cp MIT_LICENSE recursive-archive/vendor/foo/bar/baz/SOMETHING_LICENSE
 cp apache_licensed_codefile.rb recursive-archive/vendor/foo/bar/baz/something.rb
 cp apache_licensed_codefile.rb recursive-archive/vendor/foo/bar/bar_apache.rb
 cp MIT_LICENSE recursive-archive/vendor/foo/bar
+
 if [[ "$include_targets" == "true" ]]; then
   cp package.json recursive-archive/vendor/foo/bar/baz/quux
   cp pom.xml recursive-archive/vendor/foo/bar/
 fi
+
 # The UUID gives us a different directory hash every time we generate
 uuidgen > recursive-archive/vendor/foo/VERSION
 
-echo "1: $1"
-if [[ "$1" == "--skip-archiving" ]]; then
+if [[ "$skip_archiving" == "true" ]]; then
   echo "Exiting early"
   exit 0
 fi

--- a/recursive-archive-generator/generate
+++ b/recursive-archive-generator/generate
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Generate a recursive archive to test with
+# ./generate will generate a recursive archive
+# ./generate --include-targes will add a package.json and a pom.xml to the archives
+# ./generate --skip-archiving will just create the directory structure, but skip the archiving
+
 WORKING_DIR=`pwd`
 echo "WORKING_DIR = $WORKING_DIR"
 

--- a/recursive-archive-generator/package.json
+++ b/recursive-archive-generator/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "yarn-testing",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bson": "4.5.1",
+    "bxslider": "^4.2.14"
+  },
+  "devDependencies": {
+    "@storybook/addon-actions": "6.3.7",
+    "@storybook/addon-docs": "6.3.7"
+  }
+}

--- a/recursive-archive-generator/pom.xml
+++ b/recursive-archive-generator/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>4701-mavendeps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+       <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-databind</artifactId>
+         <!-- <version>2.13.3</version> -->
+       </dependency>
+
+    </dependencies>
+</project>


### PR DESCRIPTION
Add a package.json and pom.xml to the recursive archive if you add the `--include-targets` flag

```
cd recursive-archive-generator
./generate --skip-archiving --include-targets 
tree recursive-archive

recursive-archive
└── vendor
    └── foo
        ├── VERSION
        └── bar
            ├── MIT_LICENSE
            ├── bar_apache.rb
            ├── baz
            │   ├── SOMETHING_LICENSE
            │   ├── quux
            │   │   ├── QUUX_LICENSE
            │   │   └── package.json
            │   └── something.rb
            └── pom.xml
```

Without the flag, there's no target files:

```
./generate --skip-archiving                  
# tree recursive-archive 
recursive-archive
└── vendor
    └── foo
        ├── VERSION
        └── bar
            ├── MIT_LICENSE
            ├── bar_apache.rb
            └── baz
                ├── SOMETHING_LICENSE
                ├── quux
                │   └── QUUX_LICENSE
                └── something.rb
```
